### PR TITLE
Restyling the home page

### DIFF
--- a/nVolve/Features/Content/ContentView.swift
+++ b/nVolve/Features/Content/ContentView.swift
@@ -17,20 +17,25 @@ struct ContentView: View {
         ZStack {
             VStack(spacing: 0) {
                 // App Header
-                HStack {
-                    Spacer()
+                ZStack {
+                    // Centered Logo
                     Image("tu-involved")
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 100, height: 40)
+                        .frame(width: 150, height: 60)
                         .onTapGesture {
                             position = .automatic
                         }
-                    Spacer()
-                }
 
-                // Filter Header Section
-                FilterHeader(showingFilters: $showingFilters)
+                    // Right-Aligned Filter Header
+                    HStack {
+                        Spacer()
+                        FilterHeader(showingFilters: $showingFilters)
+                    }
+                }
+                .padding(.bottom)
+
+
 
                 // Map Section
                 MapSection(

--- a/nVolve/Features/Events/EventCardView.swift
+++ b/nVolve/Features/Events/EventCardView.swift
@@ -16,52 +16,65 @@ struct EventCard: View {
     @State var showEvent: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 8) {
             // Event Image
             if let imagePath = imagePath, let url = URL(string: imagePath) {
                 AsyncImage(url: url) { image in
                     image
                         .resizable()
-                        .scaledToFit()
+                        .scaledToFill()
                         .frame(height: 120)
                         .clipped()
                         .cornerRadius(8)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color.purple, lineWidth: 1)
-                        )
                 } placeholder: {
-                    ProgressView("Loading...")
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.gray.opacity(0.3))
+                        .frame(height: 120)
+                        .overlay(
+                            ProgressView()
+                                .scaleEffect(0.8)
+                                .padding()
+                        )
                 }
             }
-            
-            VStack(alignment: .leading, spacing: 3) {
+
+            // Event Details
+            VStack(alignment: .leading, spacing: 4) {
                 Text(event?.eventName ?? "Event")
                     .font(.headline)
-                    .fontWeight(.semibold)
+                    .fontWeight(.bold)
                     .lineLimit(1)
 
-                Text("\(date) / \(event?.eventLocation ?? "Room")")
-                    .font(.caption)
-                    .bold()
+                HStack {
+                    Image(systemName: "clock.fill")
+                        .foregroundColor(Color(red: 1.0, green: 0.733, blue: 0.0))
+                    Text(date)
+                        .font(.caption)
+                        .foregroundColor(.black)
+                        .lineLimit(1)
+                }
 
-                Text(strippedEventDescription)
-                    .font(.caption)
-                    .lineLimit(2)
+                HStack {
+                    Image(systemName: "mappin.and.ellipse")
+                        .foregroundColor(Color(red: 1.0, green: 0.733, blue: 0.0))
+                    Text(event?.eventLocation ?? "Location")
+                        .font(.caption)
+                        .foregroundColor(.black)
+                        .lineLimit(1)
+                }
             }
-            .padding(8)
-            .background(Color.yellow.opacity(0.8))
-            .cornerRadius(8)
-            .foregroundColor(.black)
+            .padding([.horizontal, .bottom], 8)
         }
-        .frame(width: 180, height: 240)
-        .background(Color.white)
-        .cornerRadius(12)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.yellow, lineWidth: 1)
-        )
-        .shadow(color: Color.gray.opacity(0.2), radius: 2, x: 0, y: 1)
+        .frame(width: 200, height: 220)
+        .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.white)
+                        .shadow(color: Color.gray.opacity(0.2), radius: 4, x: 0, y: 2)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.black, lineWidth: 2)
+                )
         .onTapGesture {
             showEvent = true
         }
@@ -71,13 +84,15 @@ struct EventCard: View {
                 imagePath: imagePath,
                 title: event?.eventName ?? "Event Title",
                 time: date,
-                room: event?.eventLocation ?? "Room 204",
+                room: event?.eventLocation ?? "Room",
                 description: strippedEventDescription,
                 eventLat: event?.latitude ?? "0.0",
                 eventLng: event?.longitude ?? "0.0",
                 perks: event?.perks ?? []
             )
         }
+        .padding(.trailing, 5)
+        .padding(.vertical, 10)
     }
 }
 

--- a/nVolve/Features/Events/EventCardView.swift
+++ b/nVolve/Features/Events/EventCardView.swift
@@ -17,7 +17,7 @@ struct EventCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            // Event Image
+            // Event Image or Placeholder
             if let imagePath = imagePath, let url = URL(string: imagePath) {
                 AsyncImage(url: url) { image in
                     image
@@ -27,15 +27,10 @@ struct EventCard: View {
                         .clipped()
                         .cornerRadius(8)
                 } placeholder: {
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.gray.opacity(0.3))
-                        .frame(height: 120)
-                        .overlay(
-                            ProgressView()
-                                .scaleEffect(0.8)
-                                .padding()
-                        )
+                    placeholderImage
                 }
+            } else {
+                placeholderImage
             }
 
             // Event Details
@@ -95,6 +90,24 @@ struct EventCard: View {
         .padding(.vertical, 10)
     }
 }
+
+private var placeholderImage: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.gray.opacity(0.3))
+            .frame(height: 120)
+            .overlay(
+                VStack {
+                    Image(systemName: "photo")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 40, height: 40)
+                        .foregroundColor(.gray)
+                    Text("No Image Available")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+            )
+    }
 
 struct EventCard_Previews: PreviewProvider {
     static var previews: some View {

--- a/nVolve/Features/Events/EventInfoView.swift
+++ b/nVolve/Features/Events/EventInfoView.swift
@@ -106,6 +106,7 @@ struct EventInfo: View {
                     Spacer() // Allows scrolling content to push up
                 }
                 .padding()
+                .padding(.bottom, 80)
             }
 
             // Fixed bottom action buttons

--- a/nVolve/Features/Filters/FilterHeaderView.swift
+++ b/nVolve/Features/Filters/FilterHeaderView.swift
@@ -12,26 +12,15 @@ struct FilterHeader: View {
 
     var body: some View {
         HStack {
-            Text(
-                "Filters"
-            )
             Spacer()
             Button(
                 action: {
                     showingFilters.toggle()
                 }) {
-                    Image(
-                        systemName: "slider.horizontal.3"
-                    )
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 24)) // Increase icon size
                 }
         }
         .padding()
-        .overlay(
-            Rectangle()
-                .stroke(
-                    Color.black,
-                    lineWidth: 1
-                )
-        )
     }
 }

--- a/nVolve/Features/Map/MapSectionView.swift
+++ b/nVolve/Features/Map/MapSectionView.swift
@@ -37,7 +37,7 @@ struct MapSection: View {
                 viewModel.fetchTodayEvents()
             }
             .mapStyle(.standard)
-            .frame(height: 400)
+            .frame(height: 410)
             .colorScheme(.dark)
 
           


### PR DESCRIPTION
I made the logo bigger and removed the heading "Filters". Everybody knows the three bars in the top right means filters so there is no need to have a big heading saying "Filters". Removed the description from the event cards and styled them. Also when you click on a card and it has a long description, I added padding at the bottom so now when you scroll you can see everything.